### PR TITLE
Fix media player HomeKit representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### 2.0.0 - TBD
-- new HTD domain, 
+- new HTD domain,
 - support ConfigFlow
 - support AutoDiscovery
+- fix HomeKit device class so zones show as receivers
 
 ### 1.2.0 - July  11, 2024
 - Upgrading to HASS 2024.6.4

--- a/custom_components/htd/manifest.json
+++ b/custom_components/htd/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "htd_client==0.0.24"
   ],
-  "version": "2.0.0-rc.2"
+  "version": "2.0.0-rc.3"
 }

--- a/custom_components/htd/media_player.py
+++ b/custom_components/htd/media_player.py
@@ -3,10 +3,8 @@
 import logging
 import re
 
-from homeassistant.components.media_player import MediaPlayerEntity
-from homeassistant.components.media_player.const import (
-    MediaPlayerEntityFeature
-)
+from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerDeviceClass
+from homeassistant.components.media_player.const import MediaPlayerEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_UNIQUE_ID,
@@ -204,6 +202,8 @@ class HtdDevice(MediaPlayerEntity):
     async def async_select_source(self, source: int):
         source_index = self.sources.index(source)
         await self.client.async_set_source(self.zone, source_index + 1)
+
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     @property
     def icon(self):


### PR DESCRIPTION
## Summary
- set device class to receiver so HomeKit exposes HTD zones as media players
- update changelog entry

## Testing
- `python -m compileall -q custom_components/htd`

------
https://chatgpt.com/codex/tasks/task_e_687672f0c270832f8a13a6a1cf4f1579