### PR TITLE
Set device class and media type for HTD zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - support ConfigFlow
 - support AutoDiscovery
 - fix HomeKit device class so zones show as receivers
+- expose media content type so HomeKit recognizes zones as music players
 
 
 ### 1.2.0 - July  11, 2024

--- a/custom_components/htd/media_player.py
+++ b/custom_components/htd/media_player.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerDeviceClass
-from homeassistant.components.media_player.const import MediaPlayerEntityFeature
+from homeassistant.components.media_player.const import MediaPlayerEntityFeature, MediaType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_UNIQUE_ID,
@@ -204,6 +204,7 @@ class HtdDevice(MediaPlayerEntity):
         await self.client.async_set_source(self.zone, source_index + 1)
 
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
+    _attr_media_content_type = MediaType.MUSIC
 
     @property
     def icon(self):
@@ -211,7 +212,7 @@ class HtdDevice(MediaPlayerEntity):
 
     @property
     def device_class(self) -> MediaPlayerDeviceClass:
-        return MediaPlayerDeviceClass.SPEAKER
+        return MediaPlayerDeviceClass.RECEIVER
 
     async def async_added_to_hass(self):
         """Run when this Entity has been added to HA."""


### PR DESCRIPTION
## Summary
- flag HTD zones as receivers in `device_class`
- default `_attr_media_content_type` to music
- note HomeKit behaviour change in changelog

## Testing
- `python -m py_compile custom_components/htd/media_player.py`

------
https://chatgpt.com/codex/tasks/task_e_687a6f795164832f9e1b4d13b260f293