### PR TITLE
Fix quoting in config flow

### DIFF
--- a/custom_components/htd/config_flow.py
+++ b/custom_components/htd/config_flow.py
@@ -58,7 +58,7 @@ class HtdConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         self.context["title_placeholders"] = {
-            CONF_NAME: f"{model_info["friendly_name"]} ({host})",
+            CONF_NAME: f"{model_info['friendly_name']} ({host})",
         }
 
         return await self.async_step_custom_connection(new_user_input)


### PR DESCRIPTION
## Summary
- fix quoting around model_info lookup in config_flow

## Testing
- `python -m py_compile custom_components/htd/config_flow.py`
- `python -m py_compile custom_components/htd/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687a6f89486c832fa2d06ef6aacfc9ff