### PR TITLE
Fix quoting in config flow

### DIFF
--- a/custom_components/htd/config_flow.py
+++ b/custom_components/htd/config_flow.py
@@ -58,7 +58,7 @@ class HtdConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         self.context["title_placeholders"] = {
-            CONF_NAME: f"{model_info["friendly_name"]} ({host})",
+            CONF_NAME: f"{model_info['friendly_name']} ({host})",
         }
 
         return await self.async_step_custom_connection(new_user_input)
@@ -96,6 +96,9 @@ class HtdConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.host = host
                 self.port = port
                 self.unique_id = unique_id
+
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
 
                 return await self.async_step_options()
 

--- a/custom_components/htd/media_player.py
+++ b/custom_components/htd/media_player.py
@@ -93,8 +93,12 @@ async def async_setup_entry(_: HomeAssistant, config_entry: HtdClientConfigEntry
     async_add_entities(entities)
 
 
+
 class HtdDevice(MediaPlayerEntity):
     should_poll = False
+
+    _attr_supported_features = SUPPORT_HTD
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     unique_id: str = None
     device_name: str = None
@@ -112,7 +116,7 @@ class HtdDevice(MediaPlayerEntity):
         sources,
         client
     ):
-        self.unique_id = f"{unique_id}_{zone:02}"
+        self._attr_unique_id = f"{unique_id}_{zone:02}"
         self.device_name = device_name
         self.zone = zone
         self.client = client
@@ -124,9 +128,6 @@ class HtdDevice(MediaPlayerEntity):
     def enabled(self) -> bool:
         return self.zone_info is not None and self.zone_info.enabled
 
-    @property
-    def supported_features(self):
-        return SUPPORT_HTD
 
     @property
     def name(self):
@@ -203,15 +204,9 @@ class HtdDevice(MediaPlayerEntity):
         source_index = self.sources.index(source)
         await self.client.async_set_source(self.zone, source_index + 1)
 
-    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
-
     @property
     def icon(self):
         return "mdi:disc-player"
-
-    @property
-    def device_class(self) -> MediaPlayerDeviceClass:
-        return MediaPlayerDeviceClass.SPEAKER
 
     async def async_added_to_hass(self):
         """Run when this Entity has been added to HA."""


### PR DESCRIPTION
## Summary
- fix quoting around model_info lookup in config_flow
- expose HomeKit volume control by setting supported features and device class at class-level
- set unique_id for each HtdDevice entity
- ensure config flow sets unique_id for manual setup

## Testing
- `python3.12 -m py_compile custom_components/htd/config_flow.py`
- `python3.12 -m py_compile custom_components/htd/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687a6f89486c832fa2d06ef6aacfc9ff