### PR TITLE
Remove unused unique_id field

### DIFF
--- a/custom_components/htd/media_player.py
+++ b/custom_components/htd/media_player.py
@@ -100,7 +100,6 @@ class HtdDevice(MediaPlayerEntity):
     _attr_supported_features = SUPPORT_HTD
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
-    unique_id: str = None
 
     device_name: str = None
     client: BaseClient = None


### PR DESCRIPTION
## Summary
- delete the unused `unique_id` attribute on `HtdDevice`
- `_attr_unique_id` still set in `__init__`

## Testing
- `python -m py_compile custom_components/htd/media_player.py`


------
https://chatgpt.com/codex/tasks/task_e_687ad1445680832f9c8b09151c942265