### PR TITLE
Fix device class for HomeKit

### DIFF
--- a/custom_components/htd/media_player.py
+++ b/custom_components/htd/media_player.py
@@ -37,7 +37,7 @@ SUPPORT_HTD = (
 
 _LOGGER = logging.getLogger(__name__)
 
-type HtdClientConfigEntry = ConfigEntry[BaseClient]
+HtdClientConfigEntry = ConfigEntry[BaseClient]
 
 
 async def async_setup_platform(hass, _, async_add_entities, __=None):
@@ -99,6 +99,7 @@ class HtdDevice(MediaPlayerEntity):
 
     _attr_supported_features = SUPPORT_HTD
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
+    _attr_media_content_type = MediaType.MUSIC
 
 
     device_name: str = None
@@ -205,13 +206,12 @@ class HtdDevice(MediaPlayerEntity):
         await self.client.async_set_source(self.zone, source_index + 1)
 
 
-    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
-  
     @property
     def icon(self):
         return "mdi:disc-player"
 
-
+    @property
+    def device_class(self) -> MediaPlayerDeviceClass:
         return MediaPlayerDeviceClass.RECEIVER
 
     async def async_added_to_hass(self):


### PR DESCRIPTION
## Summary
- set `_attr_media_content_type` on `HtdDevice`
- remove leftover device class lines
- add explicit `device_class` property
- fix Python 3.12 type alias syntax

## Testing
- `python -m py_compile custom_components/htd/media_player.py`

------
https://chatgpt.com/codex/tasks/task_e_687ad424a1b4832fb5b7cc2f300f907c