### PR TITLE
Switch device class to speaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 - new HTD domain,
 - support ConfigFlow
 - support AutoDiscovery
-- fix HomeKit device class so zones show as receivers
+- fix HomeKit device class so zones show as speakers
+- ensure volume controls continue working when zones appear as speakers
 - expose media content type so HomeKit recognizes zones as music players
 
 


### PR DESCRIPTION
## Summary
- show HomeKit zones as speakers
- ensure volume controls remain functional for speaker device class

## Testing
- `python -m py_compile custom_components/htd/media_player.py`


------
https://chatgpt.com/codex/tasks/task_e_687dc1e133c8832fad9bbdd256c02d52